### PR TITLE
Use go modules outside of GOPATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ addons:
     packages:
     - docker-ce
     - pass
-script: docker build -t filebrowser/dev .
+script: docker build -t filebrowser/dev:mod .
 deploy:
   provider: script
   skip_cleanup: true
-  script: ./docker_login.sh && docker push filebrowser/dev && docker logout
+  script: ./docker_login.sh && docker push filebrowser/dev:mod && docker logout
   on:
     repo: filebrowser/docker-dev
-    branch: master
+    branch: mod

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ addons:
     packages:
     - docker-ce
     - pass
-script: docker build -t filebrowser/dev:mod .
+script: docker build -t filebrowser/dev .
 deploy:
   provider: script
   skip_cleanup: true
-  script: ./docker_login.sh && docker push filebrowser/dev:mod && docker logout
+  script: ./docker_login.sh && docker push filebrowser/dev && docker logout
   on:
     repo: filebrowser/docker-dev
-    branch: mod
+    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ FROM golang:alpine
 COPY --from=base /go/bin /go/bin
 COPY get_deps.sh ./get_deps.sh
 
+ENV CGO_ENABLED 0
+
 RUN apk --no-cache -U upgrade && apk --no-cache add ca-certificates yarn git curl dos2unix && \
   chmod +x get_deps.sh && ./get_deps.sh && rm get_deps.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,19 +9,7 @@ FROM golang:alpine
 WORKDIR /go/src/github.com/filebrowser/filebrowser
 
 COPY --from=base /go/bin /go/bin
+COPY get_deps.sh ./get_deps.sh
 
 RUN apk --no-cache -U upgrade && apk --no-cache add ca-certificates yarn git curl dos2unix && \
-  go get github.com/GeertJohan/go.rice/rice && \
-  curl -sL https://git.io/goreleaser -o /go/bin/goreleaser && \
-  chmod +x /go/bin/goreleaser && \
-  curl -fsSL https://download.docker.com/linux/static/edge/x86_64/docker-18.05.0-ce.tgz | tar xvz --strip-components=1 docker/docker -C /go/bin && \
-  chmod +x /go/bin/docker && \
-  curl -fsSL $( \
-    curl -s https://api.github.com/repos/docker/docker-credential-helpers/releases/latest \
-    | grep "browser_download_url.*pass-.*-amd64"  \
-    | cut -d : -f 2,3 \
-    | tr -d \" \
-  ) | tar xv -C /go/bin && \
-  chmod + /go/bin/docker-credential-pass
-
-ENV GO111MODULE on
+  chmod +x get_deps.sh && ./get_deps.sh && rm get_deps.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,6 @@ COPY --from=base /go/bin /go/bin
 
 RUN apk --no-cache -U upgrade && apk --no-cache add ca-certificates yarn git curl dos2unix && \
   go get github.com/GeertJohan/go.rice/rice && \
-  curl -fsSL -o /go/bin/dep $( \
-    curl -s https://api.github.com/repos/golang/dep/releases/latest \
-    | grep "browser_download_url.*linux-amd64\"" \
-    | cut -d : -f 2,3 \
-    | tr -d \" \
-  ) && \
-  chmod +x /go/bin/dep && \
   curl -sL https://git.io/goreleaser -o /go/bin/goreleaser && \
   chmod +x /go/bin/goreleaser && \
   curl -fsSL https://download.docker.com/linux/static/edge/x86_64/docker-18.05.0-ce.tgz | tar xvz --strip-components=1 docker/docker -C /go/bin && \
@@ -30,3 +23,5 @@ RUN apk --no-cache -U upgrade && apk --no-cache add ca-certificates yarn git cur
     | tr -d \" \
   ) | tar xv -C /go/bin && \
   chmod + /go/bin/docker-credential-pass
+
+ENV GO111MODULE on

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ RUN apk add -U --no-cache git && \
 
 FROM golang:alpine
 
-WORKDIR /go/src/github.com/filebrowser/filebrowser
-
 COPY --from=base /go/bin /go/bin
 COPY get_deps.sh ./get_deps.sh
 

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -18,11 +18,15 @@ chmod +x /go/bin/docker
 
 #-- docker-credential-pass
 
-curl -fsSL $( \
-  curl -s https://api.github.com/repos/docker/docker-credential-helpers/releases/latest \
-  | grep "browser_download_url.*pass-.*-amd64"  \
+PASS_URL="$(curl -s https://api.github.com/repos/docker/docker-credential-helpers/releases/latest \
+  | grep "browser_download_url.*pass-.*-amd64" \
   | cut -d : -f 2,3 \
-  | tr -d \" \
-) | tar xv -C /go/bin
+  | tr -d \")"
+
+if [ "$(echo "$PASS_URL" | cut -c2-6)" != "https" ]; then
+  PASS_URL="https://github.com/docker/docker-credential-helpers/releases/download/v0.6.0/docker-credential-pass-v0.6.0-amd64.tar.gz"
+fi
+
+curl -fsSL "$PASS_URL" | tar xv -C /go/bin
 
 chmod + /go/bin/docker-credential-pass

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+#-- go.rice
+
+go get github.com/GeertJohan/go.rice/rice
+
+#-- goreleaser
+
+curl -sL https://git.io/goreleaser -o /go/bin/goreleaser
+
+chmod +x /go/bin/goreleaser
+
+#-- docker
+
+curl -fsSL https://download.docker.com/linux/static/edge/x86_64/docker-18.05.0-ce.tgz | tar xvz --strip-components=1 docker/docker -C /go/bin
+
+chmod +x /go/bin/docker
+
+#-- docker-credential-pass
+
+curl -fsSL $( \
+  curl -s https://api.github.com/repos/docker/docker-credential-helpers/releases/latest \
+  | grep "browser_download_url.*pass-.*-amd64"  \
+  | cut -d : -f 2,3 \
+  | tr -d \" \
+) | tar xv -C /go/bin
+
+chmod + /go/bin/docker-credential-pass


### PR DESCRIPTION
This PR allows to bind the root of filebrowser/filebrowser to any path outside of `GOPATH`. Furthermore, `CGO_ENABLED=0` is set, so that it is not required to set it in every script. Last, a workaround is added in order to use a fixed URL when GitHub API calls fail to get the URL of the latest docker-credential-pass binary (which is quite frequent on Travis).